### PR TITLE
Update 0013-fedora-rpm.patch

### DIFF
--- a/linux-tkg-patches/6.6/0013-fedora-rpm.patch
+++ b/linux-tkg-patches/6.6/0013-fedora-rpm.patch
@@ -1,40 +1,47 @@
 diff --git a/scripts/package/kernel.spec b/scripts/package/kernel.spec
-index 8049f0e2c..de170760d 100755
+index 3eee0143e0c5..ece7078c0741 100644
 --- a/scripts/package/kernel.spec
 +++ b/scripts/package/kernel.spec
-@@ -18,2 +18,3 @@ $S	Source2: diff.patch
- Provides: kernel-$KERNELRELEASE
-+Provides: kernel-uname-r = %{version}
- BuildRequires: bc binutils bison dwarves
-@@ -28,4 +29,4 @@ $S	BuildRequires: gcc make openssl openssl-devel perl python3 rsync
+@@ -27,8 +27,8 @@ The Linux Kernel, the operating system core itself
+ %package headers
+ Summary: Header files for the Linux kernel for use by glibc
  Group: Development/System
 -Obsoletes: kernel-headers
  Provides: kernel-headers = %{version}
 +Provides: installonlypkg(kernel) = %{version}
  %description headers
-@@ -41,2 +42,5 @@ $S$M	Summary: Development package for building kernel modules to match the $__KE
- $S$M	Group: System Environment/Kernel
-+$S$M	Provides: kernel-devel = %{version}
-+$S$M	Provides: kernel-devel-uname-r = %{version}
-+$S$M	Provides: installonlypkg(kernel) = %{version}
- $S$M	AutoReqProv: no
-@@ -46,2 +50,18 @@ $S$M	against the $__KERNELRELEASE kernel package.
- $S$M
-+$S	# Opt out of a lot of Fedora hardening flags etc...
-+$S	# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
-+$S	%undefine _package_note_file
-+$S	%undefine _auto_set_build_flags
-+$S	%undefine _include_frame_pointers
-+$S	%define _build_id_flags -Wl,--build-id=none
-+$S	%undefine _annotated_build
-+$S	%undefine _fortify_level
-+$S	%undefine _hardened_build
-+$S	%global _lto_cflags %{nil}
-+$S	%global _configure_gnuconfig_hack 0
-+$S	%global _configure_libtool_hardening_hack 0
-+$S	# Nearly had to go to the deep web to find documentation on this one... Gosh
-+$S	# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
-+$S	%define _build_id_links none
-+$S
- $S	%prep
-
+ Kernel-headers includes the C header files that specify the interface
+ between the Linux kernel and userspace libraries and programs.  The
+@@ -40,12 +40,31 @@ glibc package.
+ %package devel
+ Summary: Development package for building kernel modules to match the %{version} kernel
+ Group: System Environment/Kernel
++Provides: kernel-devel = %{version}
++Provides: kernel-devel-uname-r = %{version}
++Provides: installonlypkg(kernel) = %{version}
+ AutoReqProv: no
+ %description -n kernel-devel
+ This package provides kernel headers and makefiles sufficient to build modules
+ against the %{version} kernel package.
+ %endif
+ 
++# Opt out of a lot of Fedora hardening flags etc...
++# See https://src.fedoraproject.org/rpms/redhat-rpm-config//blob/rawhide/f/buildflags.md
++%undefine _package_note_file
++%undefine _auto_set_build_flags
++%undefine _include_frame_pointers
++%define _build_id_flags -Wl,--build-id=none
++%undefine _annotated_build
++%undefine _fortify_level
++%undefine _hardened_build
++%global _lto_cflags %{nil}
++%global _configure_gnuconfig_hack 0
++%global _configure_libtool_hardening_hack 0
++# Nearly had to go to the deep web to find documentation on this one... Gosh
++# See https://github.com/rpm-software-management/rpm/blob/master/macros.in#L471
++%define _build_id_links none
++
+ %prep
+ %setup -q -n linux
+ cp %{SOURCE1} .config
+ 


### PR DESCRIPTION
The patch  was using the syntax of the mkspec file instead of that of the kernel.spec, leading to the build failing.